### PR TITLE
doc: Make pulls destination wording explicit

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,7 +56,7 @@ Quit
 
 ## Pulls
 
-> Pulls all konnectors on preference directory
+> Pulls all konnectors into ${XDG_CONFIG_HOME:-~/.config}/configstore/konitor/ 
 
 ### Help
 


### PR DESCRIPTION
So one won't believe it can be changed through some option / config file.