### PR TITLE
Repairs ESLintConfig check

### DIFF
--- a/src/check.js
+++ b/src/check.js
@@ -10,7 +10,8 @@ const lintedByEslintPrettier = {
     assert(
       eslintConfig &&
         // eslint-config- can be ommitted
-        ['eslint-config-cozy-app', 'cozy-app'].includes(eslintConfig.extends),
+        eslintConfig.extends.find(config =>
+          ['eslint-config-cozy-app', 'cozy-app'].includes(config)),
       'eslintConfig should extend from prettier'
     )
   },


### PR DESCRIPTION
On my last PR, I made a quick fix to accept `cozy-app` as well than `eslint-config-cozy-app` as value for `eslintConfig.extends`. But it was a _too quick_ fix and the syntax was wrong, and now konitor is no more able to validate a correct ESLint config.

This PR fixes that.