### PR TITLE
Check if package.json is configured in webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "fs-extra": "6.0.1",
     "inquirer": "5.2.0",
     "js-yaml": "3.11.0",
+    "json5": "^1.0.1",
     "lodash": "4.17.10",
     "mkdirp": "0.5.1",
     "request": "2.86.0",

--- a/src/check.js
+++ b/src/check.js
@@ -203,6 +203,19 @@ const assetsDirIsConfigured = {
   message: 'The ./assets directory should exist and be configured in webpack'
 }
 
+const packageJsonIsConfigured = {
+  fn: (info, assert) => {
+    assert(
+      info.webpackCopyConfig.copies('package.json'),
+      "package.json should be copied in build/ directory by webpack. \
+      Use copy-webpack-plugin. Konitor looks for a call to 'new CopyPlugin()' \
+      or 'new CopyWebpackPlugin()'."
+    )
+  },
+  nickname: 'package.json',
+  message: 'The package.json should be configured in webpack'
+}
+
 const manifestAndPackageJsonSameVersion = {
   fn: (info, assert) => {
     assert(
@@ -290,7 +303,8 @@ const prepareGitInfo = async repository => {
 
 const mkAssert = res => (assertion, warning) => {
   if (!assertion) {
-    res.warnings.push(warning)
+    // trim inner spaces for multiline warnings
+    res.warnings.push(warning.replace(/(\s)+/g, ' '))
   }
 }
 
@@ -353,6 +367,7 @@ const checks = [
   travisUsedToBuildAndDeploy,
   renovateIsConfigured,
   assetsDirIsConfigured,
+  packageJsonIsConfigured,
   manifestAndPackageJsonSameVersion,
   connectorExistsInRegistry
 ]

--- a/src/check.js
+++ b/src/check.js
@@ -11,7 +11,8 @@ const lintedByEslintPrettier = {
       eslintConfig &&
         // eslint-config- can be ommitted
         eslintConfig.extends.find(config =>
-          ['eslint-config-cozy-app', 'cozy-app'].includes(config)),
+          ['eslint-config-cozy-app', 'cozy-app'].includes(config)
+        ),
       'eslintConfig should extend from prettier'
     )
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3008,6 +3008,12 @@ json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  dependencies:
+    minimist "^1.2.0"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"


### PR DESCRIPTION
This PR add a check for `package.json` to be configured in webpack, precisely via the `copy-webpack-plugin`.

This plugin can be configured in two ways:

* verbosely
```js
new CopyPlugin([
  { from: 'assets' },
  { from: 'package.json' }
])
```
* with shorthands (the way I use)
```js
new CopyPlugin([
  'assets',
  'package.json'
])
```
So to check if a file or a directory is configured, we can test in two different ways. I felt that it was simpler to test over a JavaScript Object, so I did some Regexp parsing to extract the `CopyPlugin()` call parameter. It implied a little refactoring of the original test over `assets` directory.

And then I added the check for `package.json`.
