### PR TITLE
feat: now check if bills data is imported

### DIFF
--- a/src/helpers/manifest.js
+++ b/src/helpers/manifest.js
@@ -38,3 +38,14 @@ export const getSlug = async path => {
 
   return manifest.slug
 }
+
+/*
+ * Get the doctype for each permission
+ */
+export const getDoctypes = async path => {
+  const manifest = await getManifest(path)
+
+  return Object.values(manifest.permissions)
+    .map(perm => perm.type)
+    .filter(doctype => !['io.cozy.files', 'io.cozy.accounts'].includes(doctype))
+}


### PR DESCRIPTION
Now check the importedData.json file content for bills documents only if the manifest has io.cozy.bills permission.

This needs the future version of cozy-konnector-libs (probably 4.4.0)